### PR TITLE
More configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You need to register a **confidential** client at the OpenID Provider with the r
 | `OIDC_CLIENT_ID` | string | - | The client ID of the client registered at the OpenID Provider | - |
 | `OIDC_CLIENT_SECRET` | string | - | The client secret | - |
 | `TOKEN_SECRET` | string | `asdf` | The secret used for signing the access token (the signature algorithm is `HS256`) | `$e(rE4` |
-| `TOKEN_TTL` | duration | `2m` | The time-to-live of the access token | `2h` |
+| `TOKEN_TTL` | duration | `1h` | The time-to-live of the access token | `1h` |
 | `TOKEN_COOKIE_NAME` | string | `_couper_access_token` | The name of the cookie storing the access token | `_couper_access_token` |
 | `ORIGIN` | string | - | The origin of the service to be protected | `https://www.example.com` |
 | `ORIGIN_HOSTNAME` | string | - | The value of the HTTP host header field for the request to the protected service | - |

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ You need to register a **confidential** client at the OpenID Provider with the r
 | `OIDC_CLIENT_SECRET` | string | The client secret | - |
 | `TOKEN_SECRET` | string | The secret used for signing the access token (the signature algorithm is `HS256`) | `$e(rE4` |
 | `TOKEN_TTL` | duration | The time-to-live of the access token | `2h` |
+| `TOKEN_COOKIE_NAME` | string | The name of the cookie storing the access token | `_couper_access_token` |
 | `ORIGIN` | string | The origin of the service to be protected | `https://www.example.com` |
 | `ORIGIN_HOSTNAME` | string | The value of the HTTP host header field for the request to the protected service | - |
 
@@ -37,5 +38,5 @@ The following cookies are involved:
 
 | Name | Description |
 | :--- | :---------- |
-| `access_token` | The token providing access to the protected service |
+| access token | The token providing access to the protected service, its name is configurable via `TOKEN_COOKIE_NAME` |
 | `authvv` | A verifier used for CSRF protection during the login process |

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ _coming soon_
 
 The gateway uses the Authorization Code Grant Flow to connect to an OpenID Provider.
 
-The redirect endpoint for the flow is `/oidc/callback`.
+The redirect endpoint for the flow is `/_couper/oidc/callback`.
 
-You need to register a **confidential** client at the OpenID Provider with the redirect URI `https://<your-gateway-host>/oidc/callback`. During registration you get a client ID and a client secret.
+You need to register a **confidential** client at the OpenID Provider with the redirect URI `https://<your-gateway-host>/_couper/oidc/callback`. During registration you get a client ID and a client secret.
 
 ## Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@ You need to register a **confidential** client at the OpenID Provider with the r
 
 ## Environment Variables
 
-| Variable | Type | Description | Example |
-| :------- | :--- | :---------- | :------ |
-| `OIDC_CONFIGURATION_URL` | string | The URL of the OpenID configuration at the OpenID Provider | `https://.../.well-known/openid-configuration` |
-| `OIDC_CLIENT_ID` | string | The client ID of the client registered at the OpenID Provider | - |
-| `OIDC_CLIENT_SECRET` | string | The client secret | - |
-| `TOKEN_SECRET` | string | The secret used for signing the access token (the signature algorithm is `HS256`) | `$e(rE4` |
-| `TOKEN_TTL` | duration | The time-to-live of the access token | `2h` |
-| `TOKEN_COOKIE_NAME` | string | The name of the cookie storing the access token | `_couper_access_token` |
-| `ORIGIN` | string | The origin of the service to be protected | `https://www.example.com` |
-| `ORIGIN_HOSTNAME` | string | The value of the HTTP host header field for the request to the protected service | - |
+| Variable | Type | Default | Description | Example |
+| :------- | :--- | :------ | :---------- | :------ |
+| `OIDC_CONFIGURATION_URL` | string | - | The URL of the OpenID configuration at the OpenID Provider | `https://.../.well-known/openid-configuration` |
+| `OIDC_CLIENT_ID` | string | - | The client ID of the client registered at the OpenID Provider | - |
+| `OIDC_CLIENT_SECRET` | string | - | The client secret | - |
+| `TOKEN_SECRET` | string | `asdf` | The secret used for signing the access token (the signature algorithm is `HS256`) | `$e(rE4` |
+| `TOKEN_TTL` | duration | `2m` | The time-to-live of the access token | `2h` |
+| `TOKEN_COOKIE_NAME` | string | `_couper_access_token` | The name of the cookie storing the access token | `_couper_access_token` |
+| `ORIGIN` | string | - | The origin of the service to be protected | `https://www.example.com` |
+| `ORIGIN_HOSTNAME` | string | - | The value of the HTTP host header field for the request to the protected service | - |
 
 | Duration units | Description  |
 | :------------- | :----------- |

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ You need to register a **confidential** client at the OpenID Provider with the r
 | `TOKEN_SECRET` | string | `asdf` | The secret used for signing the access token (the signature algorithm is `HS256`) | `$e(rE4` |
 | `TOKEN_TTL` | duration | `1h` | The time-to-live of the access token | `1h` |
 | `TOKEN_COOKIE_NAME` | string | `_couper_access_token` | The name of the cookie storing the access token | `_couper_access_token` |
+| `VERIFIER_COOKIE_NAME` | string | `_couper_authvv` | The name of the cookie storing the verifier used for CSRF protection during the login process | `_couper_authvv` |
 | `ORIGIN` | string | - | The origin of the service to be protected | `https://www.example.com` |
 | `ORIGIN_HOSTNAME` | string | - | The value of the HTTP host header field for the request to the protected service | - |
 
@@ -39,4 +40,4 @@ The following cookies are involved:
 | Name | Description |
 | :--- | :---------- |
 | access token | The token providing access to the protected service, its name is configurable via `TOKEN_COOKIE_NAME` |
-| `authvv` | A verifier used for CSRF protection during the login process |
+| auth verifier | A verifier used for CSRF protection during the login process, its name is configurable via `VERIFIER_COOKIE_NAME` |

--- a/couper.hcl
+++ b/couper.hcl
@@ -17,7 +17,7 @@ server "oidc-gate" {
   }
 
   // OIDC start login
-  endpoint "/oidc/start" {
+  endpoint "/_couper/oidc/start" {
     response {
       status = 303
       headers = {
@@ -70,10 +70,10 @@ definitions {
         }
         body = <<-EOB
 <!DOCTYPE html><html><head>
-<script>location.href = "/oidc/start?url=${url_encode(relative_url(request.url))}"</script>
-<meta http-equiv="refresh" content="0;url=/oidc/start?url=${url_encode(relative_url(request.url))}"
+<script>location.href = "/_couper/oidc/start?url=${url_encode(relative_url(request.url))}"</script>
+<meta http-equiv="refresh" content="0;url=/_couper/oidc/start?url=${url_encode(relative_url(request.url))}"
 </head><body><h1>Authentication required</h1>
-<p><a href="/oidc/start?url=${url_encode(relative_url(request.url))}">Proceed to login</a></p>
+<p><a href="/_couper/oidc/start?url=${url_encode(relative_url(request.url))}">Proceed to login</a></p>
 <p>Authentication powered by <a href="https://github.com/avenga/couper-oidc-gateway" target="_blank">Couper OIDC Gateway</a></p>
 </body></html>
 EOB

--- a/couper.hcl
+++ b/couper.hcl
@@ -23,7 +23,7 @@ server "oidc-gate" {
       headers = {
         cache-control = "no-cache,no-store"
         location = "${beta_oauth_authorization_url("oidc")}&state=${url_encode(relative_url(request.query.url[0]))}"
-        set-cookie = "authvv=${beta_oauth_verifier()};HttpOnly;Secure;Path=/_couper/oidc/callback"
+        set-cookie = "${env.VERIFIER_COOKIE_NAME}=${beta_oauth_verifier()};HttpOnly;Secure;Path=/_couper/oidc/callback"
       }
     }
   }
@@ -38,7 +38,7 @@ server "oidc-gate" {
         cache-control = "no-cache,no-store"
         set-cookie = [
           "${env.TOKEN_COOKIE_NAME}=${jwt_sign("AccessToken", {})}; HttpOnly; Secure; Path=/", # cannot use Max-Age=${env.TOKEN_TTL} here as long as TOKEN_TTL is a duration, because an integer is expected for Max-Age
-          "authvv=;HttpOnly;Secure;Path=/_couper/oidc/callback;Max-Age=0"
+          "${env.VERIFIER_COOKIE_NAME}=;HttpOnly;Secure;Path=/_couper/oidc/callback;Max-Age=0"
         ]
         location = relative_url(request.query.state[0])
       }
@@ -52,7 +52,7 @@ definitions {
     client_id = env.OIDC_CLIENT_ID
     client_secret = env.OIDC_CLIENT_SECRET
     redirect_uri = "/_couper/oidc/callback"
-    verifier_value = request.cookies.authvv
+    verifier_value = request.cookies[env.VERIFIER_COOKIE_NAME]
   }
 
   jwt "AccessToken" {
@@ -95,6 +95,7 @@ defaults {
     TOKEN_SECRET = "asdf"
     TOKEN_TTL = "1h"
     TOKEN_COOKIE_NAME = "_couper_access_token"
+    VERIFIER_COOKIE_NAME = "_couper_authvv"
     ORIGIN = ""
     ORIGIN_HOSTNAME = ""
   }

--- a/couper.hcl
+++ b/couper.hcl
@@ -37,7 +37,7 @@ server "oidc-gate" {
       headers = {
         cache-control = "no-cache,no-store"
         set-cookie = [
-          "access_token=${jwt_sign("AccessToken", {})}; HttpOnly; Secure; Path=/", # cannot use Max-Age=${env.TOKEN_TTL} here as long as TOKEN_TTL is a duration, because an integer is expected for Max-Age
+          "${env.TOKEN_COOKIE_NAME}=${jwt_sign("AccessToken", {})}; HttpOnly; Secure; Path=/", # cannot use Max-Age=${env.TOKEN_TTL} here as long as TOKEN_TTL is a duration, because an integer is expected for Max-Age
           "authvv=;HttpOnly;Secure;Path=/_couper/oidc/callback;Max-Age=0"
         ]
         location = relative_url(request.query.state[0])
@@ -59,7 +59,7 @@ definitions {
     signature_algorithm = "HS256"
     key = env.TOKEN_SECRET
     signing_ttl = env.TOKEN_TTL
-    cookie = "access_token"
+    cookie = env.TOKEN_COOKIE_NAME
 
     error_handler {
       response {
@@ -94,6 +94,7 @@ defaults {
     OIDC_CONFIGURATION_URL = ""
     TOKEN_SECRET = "asdf"
     TOKEN_TTL = "2m"
+    TOKEN_COOKIE_NAME = "_couper_access_token"
     ORIGIN = ""
     ORIGIN_HOSTNAME = ""
   }

--- a/couper.hcl
+++ b/couper.hcl
@@ -23,13 +23,13 @@ server "oidc-gate" {
       headers = {
         cache-control = "no-cache,no-store"
         location = "${beta_oauth_authorization_url("oidc")}&state=${url_encode(relative_url(request.query.url[0]))}"
-        set-cookie = "authvv=${beta_oauth_verifier()};HttpOnly;Secure;Path=/oidc/callback"
+        set-cookie = "authvv=${beta_oauth_verifier()};HttpOnly;Secure;Path=/_couper/oidc/callback"
       }
     }
   }
 
   // OIDC login callback
-  endpoint "/oidc/callback" {
+  endpoint "/_couper/oidc/callback" {
     access_control = ["oidc"]
 
     response {
@@ -38,7 +38,7 @@ server "oidc-gate" {
         cache-control = "no-cache,no-store"
         set-cookie = [
           "access_token=${jwt_sign("AccessToken", {})}; HttpOnly; Secure; Path=/", # cannot use Max-Age=${env.TOKEN_TTL} here as long as TOKEN_TTL is a duration, because an integer is expected for Max-Age
-          "authvv=;HttpOnly;Secure;Path=/oidc/callback;Max-Age=0"
+          "authvv=;HttpOnly;Secure;Path=/_couper/oidc/callback;Max-Age=0"
         ]
         location = relative_url(request.query.state[0])
       }
@@ -51,7 +51,7 @@ definitions {
     configuration_url = env.OIDC_CONFIGURATION_URL
     client_id = env.OIDC_CLIENT_ID
     client_secret = env.OIDC_CLIENT_SECRET
-    redirect_uri = "/oidc/callback"
+    redirect_uri = "/_couper/oidc/callback"
     verifier_value = request.cookies.authvv
   }
 

--- a/couper.hcl
+++ b/couper.hcl
@@ -93,7 +93,7 @@ defaults {
     OIDC_CLIENT_SECRET = ""
     OIDC_CONFIGURATION_URL = ""
     TOKEN_SECRET = "asdf"
-    TOKEN_TTL = "2m"
+    TOKEN_TTL = "1h"
     TOKEN_COOKIE_NAME = "_couper_access_token"
     ORIGIN = ""
     ORIGIN_HOSTNAME = ""


### PR DESCRIPTION
Less potential for conflicts due to `/_couper` prefixed redirect endpoint and configurable cookie names.